### PR TITLE
Use new namespace layout for attribute strategies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,4 @@ gemspec
 
 group :development do
   gem 'casa-attribute', :git => 'git://github.com/AppSharing/casa-attribute.git'
-  gem 'casa-operation', :git => 'git://github.com/AppSharing/casa-operation.git'
-  gem 'casa-operation-filter', :git => 'git://github.com/AppSharing/casa-operation-filter.git'
-  gem 'casa-operation-squash', :git => 'git://github.com/AppSharing/casa-operation-squash.git'
-  gem 'casa-operation-transform', :git => 'git://github.com/AppSharing/casa-operation-transform.git'
 end

--- a/casa-attribute-title.gemspec
+++ b/casa-attribute-title.gemspec
@@ -16,9 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'casa-attribute'
-  s.add_dependency 'casa-operation-filter'
-  s.add_dependency 'casa-operation-squash'
-  s.add_dependency 'casa-operation-transform'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'coveralls'

--- a/lib/casa/attribute/title.rb
+++ b/lib/casa/attribute/title.rb
@@ -1,7 +1,7 @@
 require 'casa/attribute/definition'
-require 'casa/operation/squash/use_latest'
-require 'casa/operation/transform/identity_map'
-require 'casa/operation/filter/list'
+require 'casa/attribute/strategy/squash/use_latest'
+require 'casa/attribute/strategy/transform/identity_map'
+require 'casa/attribute/strategy/filter/list'
 
 module CASA
   module Attribute
@@ -11,11 +11,11 @@ module CASA
 
       section 'use'
 
-      squash CASA::Operation::Squash::UseLatest
+      squash CASA::Attribute::Strategy::Squash::UseLatest
 
-      filter CASA::Operation::Filter::List
+      filter CASA::Attribute::Strategy::Filter::List
 
-      transform CASA::Operation::Transform::IdentityMap
+      transform CASA::Attribute::Strategy::Transform::IdentityMap
 
     end
   end


### PR DESCRIPTION
This is meant to align with the AppSharing/casa-receiver#4 - not ready to be accepted yet, because the other repos have't been tweaked in their layout yet, but as soon as they are, this should be merged through.
